### PR TITLE
Simple data verification tests

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -25,6 +25,9 @@ docker-compose run --rm localedb load pop AK
 ## Load vaccination data
 docker-compose run --rm localedb load vax
 
+## Test vaccination data ingest
+docker-compose run --rm localedb test vax
+
 ## Display Info
 docker-compose run --rm localedb info all
 ```

--- a/localedb
+++ b/localedb
@@ -601,6 +601,12 @@ case "$cmd" in
         
         db_init 1
         ;;
+    "test")
+        case "$2" in
+            "vax")
+                $cmd_py test-vax
+                ;;                 
+        esac;;        
     *) echo "Commands: db fs help info load setup";;
 esac
 


### PR DESCRIPTION
## What's new

This PR includes the addition of simple data verification tests. Currently this is only implemented for the vaccine (`vax`) data.

## Why does this matter

Some datasets, like the CDC Flu Vaccine data, require *substantial* transforms to get them into a format suitable for LocaleDB. There should be a way to check that, after data ingest to LocaleDB, certain queries match known truths.

## How to use this functionality

After LocaleDB setup, run:

```
## Load vaccination data
docker-compose run --rm localedb load vax

## Test vaccination data ingest
docker-compose run --rm localedb test vax
```

## Issues
This adds further complexity to the CLI interface as well as adds another `sys.arg` option to `localedb_man.py`. This could potentially be handled in a more elegant manner.